### PR TITLE
feat: predicting test set classes

### DIFF
--- a/GUI.py
+++ b/GUI.py
@@ -11,6 +11,15 @@ import warnings
 import cellphe
 import matplotlib.colors as mcolors
 from cellphe import segment_images, track_images, cell_features, import_data, time_series_features
+import tkinter as tk
+from tkinter import filedialog
+
+# Setup tkinter (only used for folder selector)
+root = tk.Tk()
+root.withdraw()
+
+# Make folder picker dialog appear on top of other windows
+root.wm_attributes('-topmost', 1)
 
 # Suppress warnings
 warnings.filterwarnings('ignore')
@@ -228,15 +237,26 @@ st.title("The CellPhe Toolkit for Cell Phenotyping")
 # Create tabs
 tab1, tab2, tab3 = st.tabs(["Image Processing", "Single Population", "Multiple Populations"])
 
+if 'image_folder' not in st.session_state:
+    image_folder = ' '
+else:
+    image_folder = st.session_state.image_folder
+
 # Tab 1: Image Processing
 with tab1:
-    st.header("Image Processing")
-    # Folder selection for image processing
-    image_folder = st.text_input("Enter the path to the folder containing the images:")
+    st.markdown("# Image Processing")
+    col1, col2 = st.columns([0.3, 0.7], vertical_alignment='center')
+    with col1:
+        clicked = st.button("Select image folder")
+    with col2:
+        st.markdown(f"Selected folder: `{image_folder}`")
+    if clicked:
+        st.session_state.image_folder = filedialog.askdirectory(master=root)
+        st.rerun()
 
     # Button to start processing
-    if st.button("Process Images"):
-        if image_folder:
+    if image_folder != ' ':
+        if st.button("Process Images"):
             st.write(f"Processing images from folder: {image_folder}")
             # Call the process_images function (Assuming it is defined elsewhere in your code)
             ts_variables = process_images(image_folder)
@@ -245,12 +265,10 @@ with tab1:
                 st.write("Time series feature extraction completed.")
             else:
                 st.write("No time series features extracted.")
-        else:
-            st.warning("Please enter a valid image folder path.")
 
 # Tab 2: Single Population Characterisation
 with tab2:
-    st.header("Single Population Temporal Characterisation")
+    st.markdown("# Single Population Temporal Characterisation")
     st.markdown("Analysis a single population's temporal characteristics, as obtained by the `cell_features()` function.")
 
     # Allow user to upload a CSV file containing cell features
@@ -269,6 +287,7 @@ with tab2:
             st.error("Upload a feature set of the cells on each frame as output by the cell_features() function in CellPhe.")
         else:
             # Store the data in session state to retain across interactions
+            # TODO needed? never seems to be accessed
             st.session_state['new_features_df'] = new_features_df
             
             # Dropdown for CellID

--- a/GUI.py
+++ b/GUI.py
@@ -424,9 +424,6 @@ with tab3:
                     # Classify the cells using the cleaned training data
                     predictions = cellphe.classification.classify_cells(train_x, train_y, test_x)
 
-                    # Print the shape for debugging
-                    st.write("Predictions Shape:", predictions.shape)
-
                     # Create DataFrame from predictions using only the 4th column (index 3)
                     predictions_df = pd.DataFrame({
                         'CellID': test_df['CellID'],

--- a/GUI.py
+++ b/GUI.py
@@ -87,6 +87,9 @@ def process_images(image_folder, framerate=0.0028):
     if not os.path.exists(masks_folder):
         os.makedirs(masks_folder)
 
+    # TODO should these be temporary folders? or user configurable? Ultimately
+    # the user doesn't need to keep the ROIs and Masks
+
     tracked_csv = os.path.join(image_folder, "../", os.path.basename(image_folder) + "_tracked.csv")
     tracked_csv = os.path.abspath(tracked_csv)
     

--- a/GUI.py
+++ b/GUI.py
@@ -276,6 +276,16 @@ else:
 # Tab 1: Image Processing
 with tab1:
     st.markdown("# Image Processing")
+    st.markdown("""
+                Run the CellPhe pipeline from start to finish on your images.
+                This contains several steps and will take some time.
+                  1. Segments the images using CellPose
+                  2. Tracks the images using TrackMate
+                  3. Imports the tracked and segmented images into CellPhe
+                  4. Generates the CellPhe cell features for each frame
+                  5. Generate the CellPhe summary features for each cell across
+                the entire time-lapse.
+                """)
     col1, col2 = st.columns([0.3, 0.7], vertical_alignment='center')
     with col1:
         clicked = st.button("Select image folder")

--- a/GUI.py
+++ b/GUI.py
@@ -16,6 +16,21 @@ from tkinter import filedialog
 
 # Setup tkinter (only used for folder selector)
 root = tk.Tk()
+# Don't show hidden files/dirs in the file dialog
+# Taken from: https://stackoverflow.com/a/54068050/1020006
+try:
+    # call a dummy dialog with an impossible option to initialize the file
+    # dialog without really getting a dialog window; this will throw a
+    # TclError, so we need a try...except :
+    try:
+        root.tk.call('tk_getOpenFile', '-foobarbaz')
+    except tk.TclError:
+        pass
+    # now set the magic variables accordingly
+    root.tk.call('set', '::tk::dialog::file::showHiddenBtn', '1')
+    root.tk.call('set', '::tk::dialog::file::showHiddenVar', '0')
+except:
+    pass
 root.withdraw()
 
 # Make folder picker dialog appear on top of other windows
@@ -254,8 +269,10 @@ with tab1:
         st.session_state.image_folder = filedialog.askdirectory(master=root)
         st.rerun()
 
+
     # Button to start processing
     if image_folder != ' ':
+        # TODO Validate that the folder contains images
         if st.button("Process Images"):
             st.write(f"Processing images from folder: {image_folder}")
             # Call the process_images function (Assuming it is defined elsewhere in your code)

--- a/GUI.py
+++ b/GUI.py
@@ -1,3 +1,4 @@
+import time
 import os
 import pandas as pd
 import streamlit as st
@@ -293,31 +294,32 @@ with tab2:
                     st.warning("FrameID column not found in data.")
 
             with col2:
-                # Plot density plots (KDE) for the selected feature across all frames
-                frame_groups = new_features_df.groupby("FrameID")[selected_feature]
-
+                n_frames = new_features_df['FrameID'].unique().size
+                color_map = plt.cm.viridis(np.linspace(1, 0, n_frames))
                 plt.figure(figsize=(10, 6))
-                color_map = plt.cm.viridis(np.linspace(0, 1, len(frame_groups)))
-
-                # Plot KDE for each frame with the corresponding color
-                for i, (frame_id, group) in enumerate(frame_groups):
-                    sns.kdeplot(group, color=color_map[i], linewidth=2)
-
+                new_features_df['FrameID_rev'] = -1 * new_features_df['FrameID']
+                sns.kdeplot(new_features_df,
+                            x=selected_feature,
+                            hue='FrameID_rev',
+                            linewidth=1,
+                            palette=color_map,
+                            legend=False,
+                            common_norm=False
+                           )
                 plt.title(f'Density Plot of {selected_feature} by Frame')  # Changed to "Frame"
                 plt.xlabel(selected_feature)
                 plt.ylabel("Density")
 
                 # Add a color bar using the Viridis color map
-                norm = plt.Normalize(0, len(frame_groups) - 1)
+                norm = plt.Normalize(0, n_frames - 1)
                 sm = plt.cm.ScalarMappable(cmap='viridis', norm=norm)
                 sm.set_array([])  # Only needed for Matplotlib 3.1 and later
 
                 # Create colorbar using the current axes
                 cbar = plt.colorbar(sm, ax=plt.gca())
-                cbar.set_ticks(np.linspace(0, len(frame_groups) - 1, 5))  # Set to fewer intervals, e.g., 5
-                cbar.set_ticklabels([int(i) for i in np.linspace(0, len(frame_groups) - 1, 5)])  # Customize tick labels
+                cbar.set_ticks(np.linspace(0, n_frames - 1, 5))  # Set to fewer intervals, e.g., 5
+                cbar.set_ticklabels([int(i) for i in np.linspace(0, n_frames - 1, 5)])  # Customize tick labels
                 cbar.set_label('Frame')  # Changed to "Frame"
-
                 st.pyplot(plt.gcf())
 
 # Tab 3: PCA & Separation Scores

--- a/GUI.py
+++ b/GUI.py
@@ -323,10 +323,6 @@ with tab2:
         elif "FrameID" not in new_features_df.columns:
             st.error("Upload a feature set of the cells on each frame as output by the cell_features() function in CellPhe.")
         else:
-            # Store the data in session state to retain across interactions
-            # TODO needed? never seems to be accessed
-            st.session_state['new_features_df'] = new_features_df
-            
             # Dropdown for CellID
             col1, col2 = st.columns(2)
             with col1:

--- a/GUI.py
+++ b/GUI.py
@@ -14,6 +14,8 @@ from cellphe import segment_images, track_images, cell_features, import_data, ti
 # Suppress warnings
 warnings.filterwarnings('ignore')
 
+EXCLUDE_ANALYSIS_COLUMNS = ['CellID', 'FrameID', 'ROI_filename']
+
 # Function to assign feature categories based on substrings in the feature names
 def assign_color(feature, colour_mapping):
     # Check for substrings to assign to a group
@@ -124,7 +126,7 @@ def plot_sep_and_pca_side_by_side(sep_df, top_features, data, labels):
     sep_df['Colour'] = sep_df['Feature'].apply(assign_color, colour_mapping=colour_mapping)
 
     # Create two columns for side-by-side plotting
-    col1, col2 = st.columns(2)
+    col1, col2 = st.columns(2, vertical_alignment="center")
 
     # Column 1: Separation Scores
     with col1:
@@ -269,58 +271,61 @@ with tab2:
             st.session_state['new_features_df'] = new_features_df
             
             # Dropdown for CellID
-            cell_id = st.selectbox("Select CellID", new_features_df["CellID"].unique())
-
+            col1, col2 = st.columns(2)
+            with col1:
+                cell_id = st.selectbox("Select CellID", new_features_df["CellID"].unique())
+            with col2:
+                # Exclude 'FrameID' and 'roi_filename' from the dropdown
+                selected_feature = st.selectbox("Select Feature", [col for col in new_features_df.columns if col not in EXCLUDE_ANALYSIS_COLUMNS])
             # Filter the dataframe based on the selected CellID
             cell_data = new_features_df[new_features_df["CellID"] == cell_id]
+            # Plot time-series and densities
+            col1, col2 = st.columns(2, vertical_alignment="center")
+            with col1:
+                # Plot the selected feature against FrameID (line plot)
+                if "FrameID" in cell_data.columns:
+                    plt.figure(figsize=(10, 6))
+                    plt.plot(cell_data["FrameID"], cell_data[selected_feature], linewidth=3)
+                    plt.title(f"Time Series of {selected_feature} for CellID {cell_data['CellID'].values[0]}")
+                    plt.grid(False)  # Remove the grid
+                    st.pyplot(plt.gcf())
+                else:
+                    st.warning("FrameID column not found in data.")
 
-            # Exclude 'FrameID' and 'roi_filename' from the dropdown
-            exclude_columns = ['CellID', 'FrameID', 'ROI_filename']
-            selected_feature = st.selectbox("Select Feature", [col for col in cell_data.columns if col not in exclude_columns])
+            with col2:
+                # Plot density plots (KDE) for the selected feature across all frames
+                frame_groups = new_features_df.groupby("FrameID")[selected_feature]
 
-            st.header(f'Time Series Plot: {selected_feature} for Cell {cell_data["CellID"].values[0]}')
-            # Plot the selected feature against FrameID (line plot)
-            if "FrameID" in cell_data.columns:
                 plt.figure(figsize=(10, 6))
-                plt.plot(cell_data["FrameID"], cell_data[selected_feature], linewidth=3)
-                plt.title(f"Time Series of {selected_feature} for CellID {cell_data['CellID'].values[0]}")
-                plt.grid(False)  # Remove the grid
+                color_map = plt.cm.viridis(np.linspace(0, 1, len(frame_groups)))
+
+                # Plot KDE for each frame with the corresponding color
+                for i, (frame_id, group) in enumerate(frame_groups):
+                    sns.kdeplot(group, color=color_map[i], linewidth=2)
+
+                plt.title(f'Density Plot of {selected_feature} by Frame')  # Changed to "Frame"
+                plt.xlabel(selected_feature)
+                plt.ylabel("Density")
+
+                # Add a color bar using the Viridis color map
+                norm = plt.Normalize(0, len(frame_groups) - 1)
+                sm = plt.cm.ScalarMappable(cmap='viridis', norm=norm)
+                sm.set_array([])  # Only needed for Matplotlib 3.1 and later
+
+                # Create colorbar using the current axes
+                cbar = plt.colorbar(sm, ax=plt.gca())
+                cbar.set_ticks(np.linspace(0, len(frame_groups) - 1, 5))  # Set to fewer intervals, e.g., 5
+                cbar.set_ticklabels([int(i) for i in np.linspace(0, len(frame_groups) - 1, 5)])  # Customize tick labels
+                cbar.set_label('Frame')  # Changed to "Frame"
+
                 st.pyplot(plt.gcf())
-            else:
-                st.warning("FrameID column not found in data.")
-
-            # Plot density plots (KDE) for the selected feature across all frames
-            st.header(f'Density Plots for Feature: {selected_feature}')
-            frame_groups = new_features_df.groupby("FrameID")[selected_feature]
-
-            plt.figure(figsize=(10, 6))
-            color_map = plt.cm.viridis(np.linspace(0, 1, len(frame_groups)))
-
-            # Plot KDE for each frame with the corresponding color
-            for i, (frame_id, group) in enumerate(frame_groups):
-                sns.kdeplot(group, color=color_map[i], linewidth=2)
-
-            plt.title(f'Density Plot of {selected_feature} by Frame')  # Changed to "Frame"
-            plt.xlabel(selected_feature)
-            plt.ylabel("Density")
-
-            # Add a color bar using the Viridis color map
-            norm = plt.Normalize(0, len(frame_groups) - 1)
-            sm = plt.cm.ScalarMappable(cmap='viridis', norm=norm)
-            sm.set_array([])  # Only needed for Matplotlib 3.1 and later
-
-            # Create colorbar using the current axes
-            cbar = plt.colorbar(sm, ax=plt.gca())
-            cbar.set_ticks(np.linspace(0, len(frame_groups) - 1, 5))  # Set to fewer intervals, e.g., 5
-            cbar.set_ticklabels([int(i) for i in np.linspace(0, len(frame_groups) - 1, 5)])  # Customize tick labels
-            cbar.set_label('Frame')  # Changed to "Frame"
-
-            st.pyplot(plt.gcf())
 
 # Tab 3: PCA & Separation Scores
 with tab3:
-    st.header("PCA and Separation Scores")
-    st.markdown("Select the number of groups you want to analyze. They will be compared on their time-series features (as output by the `time_series_features` function in CellPhe).")
+    st.markdown("# PCA and Separation Scores")
+    st.markdown("""Select the number of groups you want to analyze. They will be
+                compared on their time-series features (as output by the
+                `time_series_features` function in CellPhe).""")
 
     # Allow user to select the number of groups
     num_groups = st.number_input("Enter the Number of Groups", min_value=2, max_value=10, value=2, step=1)
@@ -363,6 +368,7 @@ with tab3:
         if any(x == '' for x in input_labels):
             st.warning("Please enter a name for every group")
         else:
+            combined_data = pd.concat(dataframes, ignore_index=True)
             # Calculate separation scores for all groups at once
             sep = cellphe.separation.calculate_separation_scores(dataframes)
 
@@ -372,46 +378,50 @@ with tab3:
             # Slider for selecting the top number of discriminatory features to display
             most_discriminatory = cellphe.separation.optimal_separation_features(sep_sorted)
             num_most_discriminatory = len(most_discriminatory)
+
+            
+            st.markdown("## Exploratory plots")
+            st.write("Rather than using all the available 1111 features, which contain can overlapping information, it can sometimes be useful to restrict analysis to a smaller subset of the features. Changing this slider will affect the number of features used in all downstream analyses, including: plotting the separation scores, the PCA plot, classifying new cells.")
             n = st.slider(
-                "Select number of top discriminatory features to use for downstream analyses",
+                "Number of features",
                 1, len(sep_sorted), num_most_discriminatory
             )
 
             # Get the top n separation scores for display and analysis
             top_sep_df = sep_sorted.head(n)
+            train_features = top_sep_df['Feature']
+            all_features = combined_data.columns
 
             # Display PCA and separation scores side by side
             plot_sep_and_pca_side_by_side(
                 top_sep_df,
-                top_sep_df['Feature'].tolist(),
-                pd.concat(dataframes, ignore_index=True),
+                train_features,
+                combined_data,
                 labels
             )
 
             # Dropdown to select feature for the boxplot
-            combined_data = pd.concat(dataframes, ignore_index=True)
-            selected_feature = st.selectbox("Select Feature for Boxplot", combined_data.columns)
+            st.write(f"Compare the {num_groups} groups across features by displaying boxplots for a selected feature.")
+            col1, col2 = st.columns([0.3, 0.7], vertical_alignment="center")
+            with col1:
+                selected_feature = st.selectbox("Select Feature for Boxplot", all_features)
+            with col2:
+                plot_boxplot_with_points(combined_data, selected_feature, labels)
 
-            # Plot boxplot for the selected feature across groups
-            st.write("Boxplot for Selected Feature:")
-            plot_boxplot_with_points(combined_data, selected_feature, labels)
-
-            st.header("Cell Classification")
-            st.write("Upload a test dataset for classification. This must have the same columns as the training data.")
+            st.divider()
+            st.markdown("# Classification of new cells")
+            st.write("Upload a test dataset for classification to see how the cells compare to the training data. This must have the same columns as the training data.")
             test_file = st.file_uploader("Upload Test CSV File", type=["csv"])
 
             if test_file is not None:
                 test_df = pd.read_csv(test_file)
                 test_df = test_df.dropna()
-                if test_df.empty or not all(col in test_df.columns for col in top_sep_df['Feature'].tolist()):
+                if test_df.empty or not all(col in test_df.columns for col in train_features):
                     st.error("The test dataset is invalid or does not contain the necessary features.")
                 else:
                     # Use n directly for the number of features for classification
                     # Select top n features from each dataframe for training
-                    train_features = top_sep_df['Feature'].tolist()
-                    train_x = pd.concat(
-                        [df[train_features] for df in dataframes], ignore_index=True
-                    ).iloc[:, :n]
+                    train_x = combined_data[train_features]
                     train_y = np.array(labels)
 
                     # Remove rows with NaN values from the training data
@@ -422,20 +432,21 @@ with tab3:
                     test_x = test_df[train_features].iloc[:, :n]
 
                     # Classify the cells using the cleaned training data
-                    predictions = cellphe.classification.classify_cells(train_x, train_y, test_x)
-
-                    # Create DataFrame from predictions using only the 4th column (index 3)
-                    predictions_df = pd.DataFrame({
-                        'CellID': test_df['CellID'],
-                        'Predicted': predictions[:, 3],
-                    })
+                    test_df['Predicted'] = cellphe.classification.classify_cells(train_x, train_y, test_x)[:, 3]
 
                     # Display pie chart of predicted class distribution if user does not have true labels
-                    st.write("Classification Distribution:")
-                    pie_data = predictions_df['Predicted'].value_counts()
+                    st.write("Distribution of predicted cell classes:")
+                    pie_data = test_df['Predicted'].value_counts()
                     plt.figure(figsize=(8, 6))
                     plt.pie(pie_data, labels=pie_data.index, autopct='%1.1f%%', startangle=90)
-                    plt.title('Predicted Class Distribution')
                     st.pyplot(plt.gcf())
+
+                    st.write("Use the dropdown below to investigate the differences in the features between the predicted classes for the test set.")
+                    col1, col2 = st.columns([0.3, 0.7], vertical_alignment="center")
+                    with col1:
+                        selected_feature_test = st.selectbox("Select Feature for test set Boxplot", all_features)
+                    with col2:
+                        st.write("Boxplot for Selected Feature:")
+                        plot_boxplot_with_points(test_df, selected_feature_test, test_df['Predicted'])
     else:
         st.warning("Please upload a valid CSV for every group.")

--- a/GUI.py
+++ b/GUI.py
@@ -41,6 +41,19 @@ warnings.filterwarnings('ignore')
 
 EXCLUDE_ANALYSIS_COLUMNS = ['CellID', 'FrameID', 'ROI_filename']
 
+def number_tifs_in_folder(folder: str):
+    """
+    Checks whether there is at least one TIF in the specified folder.
+
+    :param folder: The folder to check.
+    :return: A boolean where True indicates at least one TIF is in the
+    directory.
+    """
+    contents = [x for x in os.listdir(image_folder) if
+                os.path.isfile(os.path.join(image_folder, x))]
+    extensions = [os.path.splitext(x)[1] for x in contents]
+    return sum(x == '.tif' for x in extensions)
+
 # Function to assign feature categories based on substrings in the feature names
 def assign_color(feature, colour_mapping):
     # Check for substrings to assign to a group
@@ -272,16 +285,20 @@ with tab1:
 
     # Button to start processing
     if image_folder != ' ':
-        # TODO Validate that the folder contains images
-        if st.button("Process Images"):
-            st.write(f"Processing images from folder: {image_folder}")
-            # Call the process_images function (Assuming it is defined elsewhere in your code)
-            ts_variables = process_images(image_folder)
-            
-            if not ts_variables.empty:
-                st.write("Time series feature extraction completed.")
-            else:
-                st.write("No time series features extracted.")
+        # Validate that the folder contains images
+        if (n_tifs := number_tifs_in_folder(image_folder)) == 0:
+            st.warning("No TIFs found in folder")
+        else:
+            st.info(f"Found {n_tifs} images.")
+            if st.button("Process Images"):
+                st.write(f"Processing images from folder: {image_folder}")
+                # Call the process_images function (Assuming it is defined elsewhere in your code)
+                ts_variables = process_images(image_folder)
+
+                if not ts_variables.empty:
+                    st.write("Time series feature extraction completed.")
+                else:
+                    st.write("No time series features extracted.")
 
 # Tab 2: Single Population Characterisation
 with tab2:

--- a/GUI.py
+++ b/GUI.py
@@ -373,7 +373,7 @@ with tab3:
             most_discriminatory = cellphe.separation.optimal_separation_features(sep_sorted)
             num_most_discriminatory = len(most_discriminatory)
             n = st.slider(
-                "Select number of top discriminatory features to display", 
+                "Select number of top discriminatory features to use for downstream analyses",
                 1, len(sep_sorted), num_most_discriminatory
             )
 
@@ -382,9 +382,9 @@ with tab3:
 
             # Display PCA and separation scores side by side
             plot_sep_and_pca_side_by_side(
-                top_sep_df, 
-                top_sep_df['Feature'].tolist(), 
-                pd.concat(dataframes, ignore_index=True), 
+                top_sep_df,
+                top_sep_df['Feature'].tolist(),
+                pd.concat(dataframes, ignore_index=True),
                 labels
             )
 

--- a/GUI.py
+++ b/GUI.py
@@ -427,18 +427,10 @@ with tab3:
                     # Print the shape for debugging
                     st.write("Predictions Shape:", predictions.shape)
 
-                    st.text_input(f"Enter a label for the test set",
-                                  key="test_label")
-                    if 'test_label' in st.session_state:
-                        test_label = st.session_state.test_label
-                    else:
-                        test_label = 'Test Set'
-
                     # Create DataFrame from predictions using only the 4th column (index 3)
                     predictions_df = pd.DataFrame({
                         'CellID': test_df['CellID'],
                         'Predicted': predictions[:, 3],
-                        'Actual': test_label
                     })
 
                     # Display pie chart of predicted class distribution if user does not have true labels
@@ -447,22 +439,6 @@ with tab3:
                     plt.figure(figsize=(8, 6))
                     plt.pie(pie_data, labels=pie_data.index, autopct='%1.1f%%', startangle=90)
                     plt.title('Predicted Class Distribution')
-                    st.pyplot(plt.gcf())
-
-                    st.write("Comparison between Predicted and True Classes:")
-                    #st.dataframe(comparison_df, use_container_width=True)
-
-                    # Create a confusion matrix
-                    confusion_matrix = pd.crosstab(
-                        predictions_df['Predicted'], predictions_df['Actual'],
-                        rownames=['Predicted Class'], colnames=['Actual Class']
-                    )
-
-                    # Display the confusion matrix as a heatmap
-                    st.write("Confusion Matrix (Heatmap):")
-                    plt.figure(figsize=(10, 6))
-                    sns.heatmap(confusion_matrix, annot=True, fmt="d", cmap="Blues")
-                    plt.title("Confusion Matrix")
                     st.pyplot(plt.gcf())
     else:
         st.warning("Please upload a valid CSV for every group.")

--- a/GUI.py
+++ b/GUI.py
@@ -279,10 +279,10 @@ with tab2:
                 # Exclude 'FrameID' and 'roi_filename' from the dropdown
                 selected_feature = st.selectbox("Select Feature", [col for col in new_features_df.columns if col not in EXCLUDE_ANALYSIS_COLUMNS])
             # Filter the dataframe based on the selected CellID
-            cell_data = new_features_df[new_features_df["CellID"] == cell_id]
             # Plot time-series and densities
             col1, col2 = st.columns(2, vertical_alignment="center")
             with col1:
+                cell_data = new_features_df[new_features_df["CellID"] == cell_id]
                 # Plot the selected feature against FrameID (line plot)
                 if "FrameID" in cell_data.columns:
                     plt.figure(figsize=(10, 6))

--- a/GUI.py
+++ b/GUI.py
@@ -13,28 +13,33 @@ import matplotlib.colors as mcolors
 from cellphe import segment_images, track_images, cell_features, import_data, time_series_features
 import tkinter as tk
 from tkinter import filedialog
+import platform
+import sys
 
-# Setup tkinter (only used for folder selector)
-root = tk.Tk()
-# Don't show hidden files/dirs in the file dialog
-# Taken from: https://stackoverflow.com/a/54068050/1020006
-try:
-    # call a dummy dialog with an impossible option to initialize the file
-    # dialog without really getting a dialog window; this will throw a
-    # TclError, so we need a try...except :
+IS_APPLE_SILICON_MAC = sys.platform == 'darwin' and platform.processor() == 'arm'
+
+if not IS_APPLE_SILICON_MAC:
+    # Setup tkinter (only used for folder selector)
+    root = tk.Tk()
+    # Don't show hidden files/dirs in the file dialog
+    # Taken from: https://stackoverflow.com/a/54068050/1020006
     try:
-        root.tk.call('tk_getOpenFile', '-foobarbaz')
-    except tk.TclError:
+        # call a dummy dialog with an impossible option to initialize the file
+        # dialog without really getting a dialog window; this will throw a
+        # TclError, so we need a try...except :
+        try:
+            root.tk.call('tk_getOpenFile', '-foobarbaz')
+        except tk.TclError:
+            pass
+        # now set the magic variables accordingly
+        root.tk.call('set', '::tk::dialog::file::showHiddenBtn', '1')
+        root.tk.call('set', '::tk::dialog::file::showHiddenVar', '0')
+    except:
         pass
-    # now set the magic variables accordingly
-    root.tk.call('set', '::tk::dialog::file::showHiddenBtn', '1')
-    root.tk.call('set', '::tk::dialog::file::showHiddenVar', '0')
-except:
-    pass
-root.withdraw()
+    root.withdraw()
 
-# Make folder picker dialog appear on top of other windows
-root.wm_attributes('-topmost', 1)
+    # Make folder picker dialog appear on top of other windows
+    root.wm_attributes('-topmost', 1)
 
 # Suppress warnings
 warnings.filterwarnings('ignore')
@@ -288,13 +293,16 @@ with tab1:
                 """)
     col1, col2 = st.columns([0.3, 0.7], vertical_alignment='center')
     with col1:
-        clicked = st.button("Select image folder")
+        if not IS_APPLE_SILICON_MAC:
+            clicked = st.button("Select image folder")
+        else:
+            st.text_input("Image folder", key="image_folder", value=' ')
+            clicked = False
     with col2:
         st.markdown(f"Selected folder: `{image_folder}`")
     if clicked:
         st.session_state.image_folder = filedialog.askdirectory(master=root)
         st.rerun()
-
 
     # Button to start processing
     if image_folder != ' ':

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
-cellphe
-matplotlib
-numpy
-pandas
-scikit-learn
-seaborn
-streamlit
+cellphe==0.2.0
+matplotlib==3.9.2
+numpy==2.0.2
+pandas==2.2.3
+scikit-learn==1.5.2
+seaborn==0.13.2
+streamlit==1.39.0


### PR DESCRIPTION
Adds the ability to predict the class of an unseen test set.

@llwiggins I've made a start on adding this functionality. Rather than asking the user to separately upload a data frame with labels, I think it makes more sense to ask them to just input the test set text label for the test set. If we want the user to be able to upload multiple test sets then we can code that in just as you've done for the multiple training set groups.

If we only want users to upload a single test set that can contain multiple different classes, then it would be best to require that there is a `label` column in the CSV containing the actual class for each row. However, to be consistent the training data should also take this form of having a single CSV upload with a `label` column.

In my opinion it's more user friendly to allow multiple training and/or test sets as separate CSV files rather than requiring users to merge these outside of the app. I imagine in most use cases users will only run CellPhe over a single timelapse containing the same class. 

If you think this sounds sensible then I can add in the looping ability to upload multiple test sets.