### PR TITLE
feat: publish Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12-slim
+FROM python:3.12-slim AS builder
 
 WORKDIR /app
 ADD . /app 
@@ -9,10 +9,15 @@ RUN apt-get update && apt-get install -y \
     software-properties-common \
     && rm -rf /var/lib/apt/lists/*
 
-RUN pip install -r requirements.txt
+RUN pip install --no-compile --no-cache-dir --user -r requirements.txt
+
+FROM python:3.12-slim AS app
+COPY --from=builder /root/.local /root/.local
+COPY --from=builder /app/CellPheDashboard.py .
+RUN apt-get update && apt-get install -y python3-tk
 
 EXPOSE 8501
 
 HEALTHCHECK CMD curl --fail http://localhost:8501/_stcore/health
 
-ENTRYPOINT ["streamlit", "run", "CellPheDashboard.py", "--server.port=8501", "--server.address=0.0.0.0"]
+ENTRYPOINT ["python", "-m", "streamlit", "run", "CellPheDashboard.py", "--server.port=8501", "--server.address=0.0.0.0"]


### PR DESCRIPTION
Adds a Docker image that runs the dashboard, removing the need for users to build it themselves.

- [ ] Reduce Docker image size to < 10GB to fit on GitHub Container Registry
- [ ] Automatically build as part of a workflow

Closes #10 

The TKinter issue mentioned in #10 has been solved by installing the system package `python3-tk`, but a new error is raised: `TclError: no display name and no $DISPLAY environment variable`