### PR TITLE
feat: allow multiple csv uploads per group

### DIFF
--- a/CellPheDashboard.py
+++ b/CellPheDashboard.py
@@ -586,7 +586,7 @@ with tab3:
 
     # Allow user to select the number of groups
     num_groups = st.number_input(
-        "Enter the Number of Groups", min_value=2, max_value=10, value=2, step=1
+        "Enter the Number of Groups", min_value=2, value=2, step=1
     )
     st.divider()
     dataframes = []


### PR DESCRIPTION
Multiple CSV files can be uploaded per group in the time-series feature analysis tab.
The 10 group limit has also been removed, there is now no limit on the number of groups (well only the maximum integer size).