### PR TITLE
fix: deploy increased upload limit

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,8 +46,9 @@ COPY cellpose_models/ ./cellpose_models/
 RUN mkdir -p ~/.cellpose/models
 RUN wget https://www.cellpose.org/models/cyto3 -O ~/.cellpose/models/cyto3
 
-# Copy application code
+# Copy application code and config
 COPY CellPheDashboard.py .
+COPY .streamlit .streamlit
 
 EXPOSE 8501
 


### PR DESCRIPTION
By default only 200MB can be uploaded. This has been raised to 2GB in `.streamlit/config.toml`, however this file had been accidentally not included in the Docker image, so the raised limit wasn't taking effect. This is now fixed.