### PR TITLE
fix: Updated Dockerfile with changes to Debian base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,15 +4,12 @@ FROM python:3.12-slim AS builder
 RUN apt-get update && apt-get install -y \
     build-essential \
     curl \
-    software-properties-common \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
 
 # Install Python dependencies
 COPY requirements.txt ./
-# Install CPU only torch
-RUN pip install --no-compile --no-cache-dir --user torch --index-url https://download.pytorch.org/whl/cpu
 RUN pip install --no-compile --no-cache-dir --user -r requirements.txt
 
 # Application image
@@ -25,7 +22,7 @@ RUN apt-get update && apt-get install -y \
 # Install Maven
 ENV MAVEN_HOME=/opt/maven
 ENV PATH=$MAVEN_HOME/bin:$PATH
-ENV MAVEN_VERSION=3.9.10
+ENV MAVEN_VERSION=3.9.14
 RUN wget https://dlcdn.apache.org/maven/maven-3/$MAVEN_VERSION/binaries/apache-maven-$MAVEN_VERSION-bin.tar.gz -O /tmp/maven.tar.gz && \
     tar xvf /tmp/maven.tar.gz -C /opt && \
     mv /opt/apache-maven-$MAVEN_VERSION $MAVEN_HOME


### PR DESCRIPTION
software-properties-common has been removed from apt, fortunately it isn't needed for the Streamlit app so it has been removed. 

The version of Maven that was previously being used has been removed from the CDN so it has been bumped up a few patch versions to the next available release.

The Python dependency installation has also been updated following the update to `requirements.txt` explicitly specifying the CPU version of torch.